### PR TITLE
Issue/#5

### DIFF
--- a/srcs/Kqueue.cpp
+++ b/srcs/Kqueue.cpp
@@ -103,16 +103,22 @@ void	Kqueue::kqueue_process_events(SocketManager *sm)
 			}
 		}
 		else if (event_list[i].filter == EVFILT_WRITE) {
-			// c->get_data();
-			// generator response message
-			// const HttpConfig	*get_httpconfig() const;
-			std::string res_msg;
-			// event_handler.process_event(res_msg, c->get_request_message(), c->get_httpconfig(), c->get_local_sockaddr());
-			event_handler.process_event(res_msg, c->get_request_message(), c->get_local_sockaddr());
-      std::cout << "===test print res_mes===" << std::endl;
-      std::cout << res_msg << std::endl;
-			// std::string res_msg = "HTTP/1.1 200 OK\r\nServer: jsnetwork\r\nContent-Length: 31\r\nContent-Type: text/html\r\n\r\n<!DOCTYPE html>\n<html>\n</html>\n";
-			send(event_list[i].ident, res_msg.c_str(), res_msg.size(), 0);
+			if (event_list[i].flags & EV_EOF) {
+				Logger::log_error(LOG_ALERT, "%d kevent() reported about an %d reader disconnects", events, (int)event_list[i].ident);
+				sm->close_connection(c);
+			}
+			else {
+				// c->get_data();
+				// generator response message
+				// const HttpConfig	*get_httpconfig() const;
+				std::string res_msg;
+				// event_handler.process_event(res_msg, c->get_request_message(), c->get_httpconfig(), c->get_local_sockaddr());
+				event_handler.process_event(res_msg, c->get_request_message(), c->get_local_sockaddr());
+		std::cout << "===test print res_mes===" << std::endl;
+		std::cout << res_msg << std::endl;
+				// std::string res_msg = "HTTP/1.1 200 OK\r\nServer: jsnetwork\r\nContent-Length: 31\r\nContent-Type: text/html\r\n\r\n<!DOCTYPE html>\n<html>\n</html>\n";
+				send(event_list[i].ident, res_msg.c_str(), res_msg.size(), 0);
+			}
 		}
 	}
 }

--- a/srcs/Kqueue.cpp
+++ b/srcs/Kqueue.cpp
@@ -72,15 +72,14 @@ void	Kqueue::kqueue_process_events(SocketManager *sm)
 			Logger::log_error(LOG_ALERT, "%d kevent() error on %d filter:%d", events, (int)event_list[i].ident, (int)event_list[i].filter);
 			continue ;
 		}
-		if (event_list[i].flags & EV_EOF) {
-			Logger::log_error(LOG_ALERT, "%d kevent() reported about an closed connection %d", events, (int)event_list[i].ident);
-			kqueue_set_event(c, EVFILT_READ, EV_DELETE);
-			sm->close_connection(c);	// throw
-		}
 		else if (event_list[i].filter == EVFILT_READ) {
 			if (c->get_listen()) {
 				Connection *conn = c->event_accept(sm);	// throw
 				kqueue_set_event(conn, EVFILT_READ, EV_ADD);
+			}
+			else if (event_list[i].flags & EV_EOF) {
+				Logger::log_error(LOG_ALERT, "%d kevent() reported about an closed connection %d", events, (int)event_list[i].ident);
+				sm->close_connection(c);
 			}
 			else {
 				recv_len = recv(event_list[i].ident, c->buffer, BUF_SIZE, 0);
@@ -114,7 +113,6 @@ void	Kqueue::kqueue_process_events(SocketManager *sm)
       std::cout << res_msg << std::endl;
 			// std::string res_msg = "HTTP/1.1 200 OK\r\nServer: jsnetwork\r\nContent-Length: 31\r\nContent-Type: text/html\r\n\r\n<!DOCTYPE html>\n<html>\n</html>\n";
 			send(event_list[i].ident, res_msg.c_str(), res_msg.size(), 0);
-			kqueue_set_event(c, EVFILT_READ, EV_ADD);
 		}
 	}
 }


### PR DESCRIPTION
- connection socket이 close 될 때 자동으로 kqueue에서 삭제되기 때문에 불필요한 kqueue_set_event(c, EVFILT_READ, EV_DELETE); 부분을 삭제하고 sm->close_connection(c)만 실행하도록 수정하였습니다. 이로 인해 EV_EOF가 발생한 이후 EV_ERROR가 발생하던 문제가 해결되었습니다.
- event_list[I] & EV_EOF가 발생하는 경우를 EVFILT_READ인 경우와 EVFILT_WRITE인 경우 두가지 각각의 경우에 나누어 구현했습니다.

close #5 